### PR TITLE
Prefer WebGPU only with shader-f16 support

### DIFF
--- a/src/embedding/host/frame/model.ts
+++ b/src/embedding/host/frame/model.ts
@@ -20,6 +20,20 @@ async function isModelCached(repoId: string): Promise<boolean> {
 	}
 }
 
+type GpuAdapterLike = { features: { has(feature: string): boolean } };
+type GpuLike = { requestAdapter(): Promise<GpuAdapterLike | null> };
+
+async function supportsWebGpuF16(): Promise<boolean> {
+	const gpu = (navigator as Navigator & { gpu?: GpuLike }).gpu;
+	if (gpu == null) return false;
+	try {
+		const adapter = await gpu.requestAdapter();
+		return adapter?.features.has('shader-f16') ?? false;
+	} catch {
+		return false;
+	}
+}
+
 function describeLoadFailure(error: unknown, config: EmbeddingModelConfig): string {
 	const detail = error instanceof Error ? error.message : String(error);
 	const looksLikeNetwork = !navigator.onLine || /failed to fetch|network|load model file/i.test(detail);
@@ -42,8 +56,8 @@ export class EmbeddingModel {
 	}
 
 	async #initialize(onProgress?: ModelLoadProgressCallback): Promise<void> {
-		const webgpuAvailable = (navigator as Navigator & { gpu?: unknown }).gpu != null;
-		this.#device = webgpuAvailable ? 'webgpu' : 'wasm';
+		const useWebGpu = await supportsWebGpuF16();
+		this.#device = useWebGpu ? 'webgpu' : 'wasm';
 
 		if (!navigator.onLine && !(await isModelCached(this.config.repoId))) {
 			throw new Error(
@@ -55,7 +69,7 @@ export class EmbeddingModel {
 		try {
 			this.#pipeline = await pipeline('feature-extraction', this.config.repoId, {
 				device: this.#device,
-				dtype: webgpuAvailable ? 'fp16' : 'q8',
+				dtype: useWebGpu ? 'fp16' : 'q8',
 				progress_callback: onProgress ? (info: ProgressInfo) => {
 					if (info.status === 'progress') {
 						onProgress({ progress: info.progress, file: info.file, loaded: info.loaded, total: info.total });


### PR DESCRIPTION
`#initialize` treats `navigator.gpu != null` as fp16 support, but `shader-f16` is an optional WebGPU feature. On my adapter:

```js
(await navigator.gpu.requestAdapter()).features.has('shader-f16')  // returns false
```

so the pipeline gets `device: 'webgpu', dtype: 'fp16'` and throws `Could not load the English model: The device (webgpu) does not support fp16.` The model never loads. This asks the adapter directly and falls back to the existing wasm/q8 path.

It also covers a related case where `navigator.gpu` is present but `requestAdapter()` returns `null`, which previously ended up on that same broken webgpu path.

A downside is that if no `shader-f16` means no half precision, not no WebGPU affected users drop to CPU where `webgpu` + `fp32` would probably work. but fp32 is 4x the q8 download probably not ideal you could add an option to choose maybe?

You could consider informing users about them using a non preferred method. Also I haven't considered what it may do to existing installs of the plugin if the PR does get accepted.

### Testing

`npm run build` clean, `npm test` 57/57. Loaded the built `main.js` in my vault: no error, indexing runs, semantic search works aswell.